### PR TITLE
update gemspec to reflect project move

### DIFF
--- a/org-ruby.gemspec
+++ b/org-ruby.gemspec
@@ -7,14 +7,14 @@ Gem::Specification.new do |s|
   s.version = OrgRuby::VERSION
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors           = ["Brian Dewey"]
+  s.authors           = ["Brian Dewey", "Waldemar Quevedo"]
   s.date              = Time.now.strftime("%Y-%m-%d")
   s.description       = "An Org mode parser written in Ruby."
-  s.email             = "bdewey@gmail.com"
+  s.email             = "waldemar.quevedo@gmail.com"
   s.executables       = ["org-ruby"]
   s.extra_rdoc_files  = ["History.txt", "README.rdoc", "bin/org-ruby"]
   s.files             = ["History.txt", "README.rdoc", "bin/org-ruby", "lib/org-ruby.rb", "lib/org-ruby/headline.rb", "lib/org-ruby/html_output_buffer.rb", "lib/org-ruby/html_symbol_replace.rb", "lib/org-ruby/line.rb", "lib/org-ruby/output_buffer.rb", "lib/org-ruby/parser.rb", "lib/org-ruby/regexp_helper.rb", "lib/org-ruby/markdown_output_buffer.rb", "lib/org-ruby/textile_output_buffer.rb", "lib/org-ruby/textile_symbol_replace.rb", "lib/org-ruby/tilt.rb", "lib/org-ruby/version.rb"]
-  s.homepage          = "https://github.com/bdewey/org-ruby"
+  s.homepage          = "https://github.com/wallyqs/org-ruby"
   s.require_paths     = ["lib"]
   s.rubyforge_project = "org-ruby"
   s.rubygems_version  = "1.8.10"


### PR DESCRIPTION
I tried finding the project homepage via
http://rubygems.org/gems/org-ruby but it still links to the old project
page.  This updates the gemspec to point to the new one.

I also updated the primary email and authors, if I may be so bold.  The
email address is the one from the commit log.
