### PR TITLE
Handle continued number lists

### DIFF
--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -59,7 +59,7 @@ module Orgmode
     # Output buffer is entering a new mode. Use this opportunity to
     # write out one of the block tags in the HtmlBlockTag constant to
     # put this information in the HTML stream.
-    def push_mode(mode, indent, properties)
+    def push_mode(mode, indent, properties={})
       @logger.debug "Properties: #{properties}"
       super(mode, indent, properties)
       if HtmlBlockTag[mode]

--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -83,7 +83,7 @@ module Orgmode
           @logger.debug "#{mode}: <#{HtmlBlockTag[mode]}#{css_class}>"
           # Check to see if we need to restart numbering from a
           # previous interrupted li
-          if mode_is_ol?(mode) and properties.key?(HtmlBlockTag[:list_item])
+          if mode_is_ol?(mode) && properties.key?(HtmlBlockTag[:list_item])
             @output << "<#{HtmlBlockTag[mode]} start=#{properties[HtmlBlockTag[:list_item]]}#{css_class}>"
           else
             @output << "<#{HtmlBlockTag[mode]}#{css_class}>"

--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -59,9 +59,9 @@ module Orgmode
     # Output buffer is entering a new mode. Use this opportunity to
     # write out one of the block tags in the HtmlBlockTag constant to
     # put this information in the HTML stream.
-    def push_mode(mode, indent)
-      super(mode, indent)
-
+    def push_mode(mode, indent, properties)
+      @logger.debug "Properties: #{properties}"
+      super(mode, indent, properties)
       if HtmlBlockTag[mode]
         unless ((mode_is_table?(mode) and skip_tables?) or
                 (mode == :src and !@options[:skip_syntax_highlight] and defined? Pygments))
@@ -77,12 +77,17 @@ module Orgmode
                       when @options[:decorate_title]
                         " class=\"title\""
                       end
-
           add_paragraph unless @new_paragraph == :start
           @new_paragraph = true
 
           @logger.debug "#{mode}: <#{HtmlBlockTag[mode]}#{css_class}>"
-          @output << "<#{HtmlBlockTag[mode]}#{css_class}>"
+          # Check to see if we need to restart numbering from a
+          # previous interrupted li
+          if mode_is_ol?(mode) and properties.key?(HtmlBlockTag[:list_item])
+            @output << "<#{HtmlBlockTag[mode]} start=#{properties[HtmlBlockTag[:list_item]]}#{css_class}>"
+          else
+            @output << "<#{HtmlBlockTag[mode]}#{css_class}>"
+          end
           # Entering a new mode obliterates the title decoration
           @options[:decorate_title] = nil
         end
@@ -233,6 +238,10 @@ module Orgmode
     def mode_is_table?(mode)
       (mode == :table or mode == :table_row or
        mode == :table_separator or mode == :table_header)
+    end
+
+    def mode_is_ol?(mode)
+      mode == :ordered_list
     end
 
     # Escapes any HTML content in string

--- a/lib/org-ruby/line.rb
+++ b/lib/org-ruby/line.rb
@@ -36,6 +36,7 @@ module Orgmode
       @properties = { }
       determine_paragraph_type
       determine_major_mode
+      extract_properties
       @indent = $&.length unless blank?
     end
 
@@ -115,8 +116,25 @@ module Orgmode
       check_assignment_or_regexp(:ordered_list, OrderedListRegexp)
     end
 
+    ContinuedOrderedListRegexp = /^\[@(\d+)\]\s+/
+
     def strip_ordered_list_tag
-      @line.sub(OrderedListRegexp, "")
+      line = @line.sub(OrderedListRegexp, "")
+      if line =~ ContinuedOrderedListRegexp
+        line = line.sub(ContinuedOrderedListRegexp, "")
+      end
+      return line
+    end
+
+    def extract_properties
+      if @line =~ OrderedListRegexp
+        line_without_number =  @line.sub(OrderedListRegexp, "")
+        if line_without_number =~ ContinuedOrderedListRegexp
+          # Extract the start of the ordered list and store it in
+          # properties
+          @properties["li"] = line_without_number.match(ContinuedOrderedListRegexp)[1]
+        end
+      end
     end
 
     HorizontalRuleRegexp = /^\s*-{5,}\s*$/

--- a/lib/org-ruby/markdown_output_buffer.rb
+++ b/lib/org-ruby/markdown_output_buffer.rb
@@ -15,7 +15,7 @@ module Orgmode
       end
     end
 
-    def push_mode(mode, indent, properties)
+    def push_mode(mode, indent, properties={})
       super(mode, indent, properties)
     end
 

--- a/lib/org-ruby/markdown_output_buffer.rb
+++ b/lib/org-ruby/markdown_output_buffer.rb
@@ -15,8 +15,8 @@ module Orgmode
       end
     end
 
-    def push_mode(mode, indent)
-      super(mode, indent)
+    def push_mode(mode, indent, properties)
+      super(mode, indent, properties)
     end
 
     def pop_mode(mode = nil)

--- a/lib/org-ruby/output_buffer.rb
+++ b/lib/org-ruby/output_buffer.rb
@@ -46,8 +46,8 @@ module Orgmode
       @mode_stack.last
     end
 
-    
-    def push_mode(mode, indent, properties)
+
+    def push_mode(mode, indent, _)
       @mode_stack.push(mode)
       @list_indent_stack.push(indent)
     end
@@ -238,7 +238,8 @@ module Orgmode
             push_mode(line.major_mode, line.indent, line.properties) if line.major_mode
           end
           # Opens tag that precedes text immediately
-          push_mode(line.paragraph_type, line.indent, line.properties) unless line.end_block?
+          push_mode(line.paragraph_type, line.indent,
+                    line.properties) unless line.end_block?
         end
       end
     end

--- a/lib/org-ruby/output_buffer.rb
+++ b/lib/org-ruby/output_buffer.rb
@@ -46,7 +46,8 @@ module Orgmode
       @mode_stack.last
     end
 
-    def push_mode(mode, indent)
+    
+    def push_mode(mode, indent, properties)
       @mode_stack.push(mode)
       @list_indent_stack.push(indent)
     end
@@ -234,10 +235,10 @@ module Orgmode
             mode_is_block? current_mode)
           # Opens the major mode of line if it exists
           if @list_indent_stack.last != line.indent or mode_is_block? current_mode
-            push_mode(line.major_mode, line.indent) if line.major_mode
+            push_mode(line.major_mode, line.indent, line.properties) if line.major_mode
           end
           # Opens tag that precedes text immediately
-          push_mode(line.paragraph_type, line.indent) unless line.end_block?
+          push_mode(line.paragraph_type, line.indent, line.properties) unless line.end_block?
         end
       end
     end

--- a/lib/org-ruby/output_buffer.rb
+++ b/lib/org-ruby/output_buffer.rb
@@ -47,7 +47,7 @@ module Orgmode
     end
 
 
-    def push_mode(mode, indent, _)
+    def push_mode(mode, indent, properties={})
       @mode_stack.push(mode)
       @list_indent_stack.push(indent)
     end

--- a/lib/org-ruby/textile_output_buffer.rb
+++ b/lib/org-ruby/textile_output_buffer.rb
@@ -11,8 +11,8 @@ module Orgmode
       @footnotes = []
     end
 
-    def push_mode(mode, indent)
-      super(mode, indent)
+    def push_mode(mode, indent, properties)
+      super(mode, indent, properties)
       @output << "bc. " if mode_is_code? mode
       if mode == :center or mode == :quote
         @add_paragraph = false

--- a/lib/org-ruby/textile_output_buffer.rb
+++ b/lib/org-ruby/textile_output_buffer.rb
@@ -11,7 +11,7 @@ module Orgmode
       @footnotes = []
     end
 
-    def push_mode(mode, indent, properties)
+    def push_mode(mode, indent, properties={})
       super(mode, indent, properties)
       @output << "bc. " if mode_is_code? mode
       if mode == :center or mode == :quote


### PR DESCRIPTION
Adds the ability to handle lists of the type:

Here comes a multi-part list.

1. Item the first.
2. Item the second.

Here is some intermediate text.

3. [@3] Item the third.
4. Item the fourth.

Previously the second list would start at 1. This change stores some
context during the line parsing to be able to continue the numbering at
3.

Also strip the [@3] field, it should not be part of the output.


Previous output:
``` html
<p>Here comes a multi-part list.</p>
<ol>
  <li>Item the first.</li>
  <li>Item the second.</li>
</ol>
<p>Here is some intermediate text.</p>
<ol>
  <li>[@3] Item the third.</li>
  <li>Item the fourth.</li>
</ol>
```

Current output:
``` html
<p>Here comes a multi-part list.</p>
<ol>
  <li>Item the first.</li>
  <li>Item the second.</li>
</ol>
<p>Here is some intermediate text.</p>
<ol start=3>
  <li>Item the third.</li>
  <li>Item the fourth.</li>
</ol>
```
Closes: Issue #38 
@wallyqs 