### PR TITLE
Require 'pathname'

### DIFF
--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'pathname'
 
 describe Orgmode::Parser do
   it "should open ORG files" do


### PR DESCRIPTION
Pathname is not required by RSpec since version 3.2 [1]. Require Pathname explicitly to fix the following error:

```
$ rspec ./spec/parser_spec.rb:141
Run options: include {:locations=>{"./spec/parser_spec.rb"=>[141]}}
F

Failures:

  1) Orgmode::Parser with a table that begins with a separator line should parse without errors
     Failure/Error: let(:data) { Pathname.new(File.dirname(__FILE__)).join('data', 'tables.org').read }

     NameError:
       uninitialized constant Pathname
     # ./spec/parser_spec.rb:139:in `block (3 levels) in <top (required)>'
     # ./spec/parser_spec.rb:138:in `block (3 levels) in <top (required)>'
     # ./spec/parser_spec.rb:142:in `block (3 levels) in <top (required)>'

Finished in 0.00063 seconds (files took 0.13196 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/parser_spec.rb:141 # Orgmode::Parser with a table that begins with a separator line should parse without errors
```

[1] https://github.com/rspec/rspec-core/commit/05ca1c6ef49470fbbdfdf3d136c428a3c7ed27d9