### PR TITLE
recognize ipython source code blocks as python

### DIFF
--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -362,6 +362,8 @@ module Orgmode
       case lang
       when 'emacs-lisp', 'common-lisp', 'lisp'
         'scheme'
+      when 'ipython'
+        'python'
       when ''
         'text'
       else


### PR DESCRIPTION
As described in [#54](https://github.com/wallyqs/org-ruby/issues/54) it would be nice to have correct python syntax highlighting for ipython source code blocks.