### PR TITLE
Change border_forbidden regex to match org.el

### DIFF
--- a/lib/org-ruby/regexp_helper.rb
+++ b/lib/org-ruby/regexp_helper.rb
@@ -46,7 +46,7 @@ module Orgmode
       # Set up the emphasis regular expression.
       @pre_emphasis = ' \t\(\'"\{'
       @post_emphasis = '- \t\.,:!\?;\'"\)\}\\\\'
-      @border_forbidden = '\s,"\''
+      @border_forbidden = ' \t\r\n'
       @body_regexp = '.*?'
       @max_newlines = 1
       @body_regexp = "#{@body_regexp}" +

--- a/spec/regexp_helper_spec.rb
+++ b/spec/regexp_helper_spec.rb
@@ -60,4 +60,17 @@ describe Orgmode::RegexpHelper do
     end
     expect(str).to eql("\"http://www.google.com\":http://www.google.com")
   end
+
+  it "should allow quotes within code markup" do
+    e = Orgmode::RegexpHelper.new
+    map = {
+      "~" => "code"
+    }
+    n = e.rewrite_emphasis('This string contains a quote using code markup: ~"~') do |border, str|
+      "<#{map[border]}>#{str}</#{map[border]}>"
+    end
+    n = e.restore_code_snippets n
+
+    expect(n).to eql("This string contains a quote using code markup: <code>\"</code>")
+  end
 end                             # describe Orgmode::RegexpHelper


### PR DESCRIPTION
I'm not sure why the regex currently used in regexp_helper is the way it is, but stuff like \~"~ works without issue in LaTeX and html Org export but breaks in org-ruby. This patch resolves that issue but does break `rake spec`.