### PR TITLE
Remove LOAD_PATH manipulation

### DIFF
--- a/lib/org-ruby.rb
+++ b/lib/org-ruby.rb
@@ -1,5 +1,3 @@
-$:.unshift File.dirname(__FILE__) # For use/testing when no gem is installed
-
 # internal requires
 require 'org-ruby/version'
 require 'org-ruby/parser'


### PR DESCRIPTION
We should rely on rubygems or bundler to add lib to $LOAD_PATH.