### PR TITLE
Generate HTML headline id (optional)

### DIFF
--- a/lib/org-ruby/headline.rb
+++ b/lib/org-ruby/headline.rb
@@ -10,6 +10,9 @@ module Orgmode
     # asterisks, the keywords, and the tags.
     attr_reader :headline_text
 
+    # This is the "slug" of the headline text
+    attr_reader :slug
+
     # This contains the lines that "belong" to the headline.
     attr_reader :body_lines
 
@@ -61,6 +64,7 @@ module Orgmode
         end
         @keyword = nil
         parse_keywords
+        @slug = slugify(@headline_text)
       else
         raise "'#{line}' is not a valid headline"
       end
@@ -99,6 +103,19 @@ module Orgmode
         @keyword = words[0]
         @headline_text.sub!(Regexp.new("^#{@keyword}\s*"), "")
       end
+    end
+
+    def slugify(text)
+      # lower case
+      text = text.downcase
+
+      # replace spaces with dash
+      text = text.gsub(/\s+/, '-')
+
+      # remove non-alphanumeric characters
+      text = text.gsub(/[^\p{Alnum}-]/, '')
+
+      text
     end
   end                           # class Headline
 end                             # class Orgmode

--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -195,6 +195,9 @@ module Orgmode
     end
 
     def add_line_attributes headline
+      if @options[:export_heading_id] then
+        @output << "<span id=\"#{headline.slug}\"></span>"
+      end
       if @options[:export_heading_number] then
         level = headline.level
         heading_number = get_next_headline_number(level)

--- a/lib/org-ruby/parser.rb
+++ b/lib/org-ruby/parser.rb
@@ -341,6 +341,7 @@ module Orgmode
       export_options = {
         :decorate_title        => @in_buffer_settings["TITLE"],
         :export_heading_number => export_heading_number?,
+        :export_heading_id     => @parser_options[:export_heading_id],
         :export_todo           => export_todo?,
         :use_sub_superscripts  => use_sub_superscripts?,
         :export_footnotes      => export_footnotes?,

--- a/spec/output_buffer_spec.rb
+++ b/spec/output_buffer_spec.rb
@@ -16,4 +16,13 @@ describe Orgmode::OutputBuffer do
     expect(output_buffer.get_next_headline_number(4)).to eql("5.2.0.1")
   end
 
+  describe Orgmode::HtmlOutputBuffer do
+    it 'generates html ids' do
+      lines = '* Hello world!'
+      parser_options = { export_heading_id: true }
+      expected_output = '<h1><span id="hello-world"></span>Hello world!</h1>'
+      actual_output = Orgmode::Parser.new(lines, parser_options).to_html.strip
+      expect(actual_output).to eql(expected_output)
+    end
+  end
 end


### PR DESCRIPTION
Motivation is to be able to generate Table of Contents via
https://github.com/snosov1/toc-org and the links should work when a
README.org is rendered.

For example, compare the heading links at
https://gitlab.com/AmrMKayid/readme-template/blob/master/README.md#installation (via
Markdown)
vs. https://gitlab.com/swaroopch/rangoli-emacs/blob/master/README.org (via OrgMode)

It's been a while since I wrote Ruby, so I may not have followed Ruby idioms. Please do let me know so that I can fix up anything that is not consistent with the code or documentation standards.

Thank you!

----

#