### PR TITLE
Recognize js2 source code blocks as javascript

### DIFF
--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -364,6 +364,8 @@ module Orgmode
         'scheme'
       when 'ipython'
         'python'
+      when 'js2'
+        'javascript'
       when ''
         'text'
       else


### PR DESCRIPTION
I noticed that [js2-mode](https://github.com/mooz/js2-mode) blocks were not recognized by GitHub as javascript code (e.g. [here](https://github.com/theophilusx/ssh2-sftp-client/blob/master/README.org)). This PR adds `js2` as an alias for `javascript` in the HTML output.

For reference, I modeled this PR after #55 for ipython --> python.