### PR TITLE
Automagically add unique id attributes to HTML headings

### DIFF
--- a/bin/org-ruby
+++ b/bin/org-ruby
@@ -17,6 +17,10 @@ options_parser = OptionParser.new do |opts|
     options[:debug] = true
   end
 
+  opts.on("-i", "--heading-id", "Add id attribute to HTML headings") do |v|
+    options[:generate_heading_id] = true
+  end
+
   opts.on("-m", "--markup <file>", "Set Custom Markup file") do |f|
     options[:markup_file] = f
   end
@@ -43,7 +47,10 @@ begin
     puts options_parser
   else
     data = IO.read(ARGV[0])
-    p = Orgmode::Parser.new(data, (options[:markup_file] ? {:markup_file => options[:markup_file]} : {}))
+    parser_options = {}
+    parser_options.merge!(options[:markup_file] ? {:markup_file => options[:markup_file]} : {})
+    parser_options.merge!(options[:generate_heading_id] ? {:generate_heading_id => options[:generate_heading_id]} : {})
+    p = Orgmode::Parser.new(data, parser_options)
     $DEBUG = true if options[:debug]
     puts p.to_html if options[:format] == :html
     puts p.to_textile if options[:format] == :textile

--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -35,6 +35,7 @@ module Orgmode
       @new_paragraph = :start
       @footnotes = {}
       @unclosed_tags = []
+      @heading_id = []
       @logger.debug "HTML export options: #{@options.inspect}"
       @custom_blocktags = {} if @options[:markup_file]
 
@@ -195,6 +196,13 @@ module Orgmode
     end
 
     def add_line_attributes headline
+      if @options[:generate_heading_id] then
+        level = headline.level
+        @output.delete_suffix!('>')
+        @heading_id.slice!(level, @heading_id.length - level)
+        @heading_id[level-1]=headline.output_text.downcase.gsub(/\W/, "-")
+        @output << " id=\"" + @heading_id.join("--") + "\">"
+      end
       if @options[:export_heading_number] then
         level = headline.level
         heading_number = get_next_headline_number(level)

--- a/lib/org-ruby/parser.rb
+++ b/lib/org-ruby/parser.rb
@@ -346,7 +346,8 @@ module Orgmode
         :export_footnotes      => export_footnotes?,
         :link_abbrevs          => @link_abbrevs,
         :skip_syntax_highlight => @parser_options[:skip_syntax_highlight],
-        :markup_file           => @parser_options[:markup_file]
+        :markup_file           => @parser_options[:markup_file],
+        :generate_heading_id   => @parser_options[:generate_heading_id]
       }
       export_options[:skip_tables] = true if not export_tables?
       output = ""

--- a/spec/html_output_buffer_spec.rb
+++ b/spec/html_output_buffer_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Orgmode::HtmlOutputBuffer do
+  it 'generates html headings ids' do
+    lines = "* Hello\n** World"
+    parser_options = {:generate_heading_id => true}
+    expected_output = "<h1 id=\"hello\">Hello</h1>\n<h2 id=\"hello--world\">World</h2>"
+    actual_output = Orgmode::Parser.new(lines, parser_options).to_html.strip
+    expect(actual_output).to eql(expected_output)
+  end
+end


### PR DESCRIPTION
Hi there!

This PR adds the option to automatically generate id attributes for the HTML headings by setting the `:generate_heading_id` option to `true`.

I am aware that #68 tries to do a similar thing, but it uses a `<span>` inside the heading instead of adding the `id` attribute to the heading itself, like this PR achieves.

The ids of subheadings are generated based on the ids of those above it, trying to preserve uniqueness.

In a nutshell, this:

```org
* Hello
** World
```

Gets converted into:

```html
<h1 id="hello">Hello</h1>
<h2 id="hello--world">World</h2>
```

This PR also adds the `-i` flag to the `org-ruby` tool to enable this behavior.

Let me know what you think 😁 
