### PR TITLE
Use non-deprecated File.exist? method

### DIFF
--- a/lib/org-ruby/output_buffer.rb
+++ b/lib/org-ruby/output_buffer.rb
@@ -137,7 +137,7 @@ module Orgmode
     end
 
     def do_custom_markup
-      if File.exists? @options[:markup_file]
+      if File.exist? @options[:markup_file]
         load_custom_markup
         if @custom_blocktags.empty?
           no_valid_markup_found

--- a/lib/org-ruby/parser.rb
+++ b/lib/org-ruby/parser.rb
@@ -129,7 +129,7 @@ module Orgmode
 
     # Check include file availability and permissions
     def check_include_file(file_path)
-      can_be_included = File.exists? file_path
+      can_be_included = File.exist? file_path
 
       if not ENV['ORG_RUBY_INCLUDE_ROOT'].nil?
         # Ensure we have full paths


### PR DESCRIPTION
File.exists? has been deprecated for some time and is no longer present in Ruby 3.2. With this change the specs pass again on Ruby 3.2.