### PR TITLE
Update test suite for new Ruby and Highlighting

### DIFF
--- a/lib/org-ruby/output_buffer.rb
+++ b/lib/org-ruby/output_buffer.rb
@@ -137,7 +137,7 @@ module Orgmode
     end
 
     def do_custom_markup
-      if File.exists? @options[:markup_file]
+      if File.exist? @options[:markup_file]
         load_custom_markup
         if @custom_blocktags.empty?
           no_valid_markup_found

--- a/lib/org-ruby/parser.rb
+++ b/lib/org-ruby/parser.rb
@@ -129,7 +129,7 @@ module Orgmode
 
     # Check include file availability and permissions
     def check_include_file(file_path)
-      can_be_included = File.exists? file_path
+      can_be_included = File.exist? file_path
 
       if not ENV['ORG_RUBY_INCLUDE_ROOT'].nil?
         # Ensure we have full paths

--- a/spec/html_code_syntax_highlight_examples/advanced-code-pygments.html
+++ b/spec/html_code_syntax_highlight_examples/advanced-code-pygments.html
@@ -18,29 +18,29 @@
 <p>And this:</p>
 <div class="highlight"><pre><span></span><span class="c1"># Finds all emphasis matches in a string.</span>
 <span class="c1"># Supply a block that will get the marker and body as parameters.</span>
-<span class="k">def</span> <span class="nf">match_all</span><span class="p">(</span><span class="n">str</span><span class="p">)</span>
-  <span class="n">str</span><span class="o">.</span><span class="n">scan</span><span class="p">(</span><span class="vi">@org_emphasis_regexp</span><span class="p">)</span> <span class="k">do</span> <span class="o">|</span><span class="n">match</span><span class="o">|</span>
-    <span class="k">yield</span> <span class="vg">$2</span><span class="p">,</span> <span class="vg">$3</span>
-  <span class="k">end</span>
+<span class="k">def</span><span class="w"> </span><span class="nf">match_all</span><span class="p">(</span><span class="n">str</span><span class="p">)</span>
+<span class="w">  </span><span class="n">str</span><span class="o">.</span><span class="n">scan</span><span class="p">(</span><span class="vi">@org_emphasis_regexp</span><span class="p">)</span><span class="w"> </span><span class="k">do</span><span class="w"> </span><span class="o">|</span><span class="n">match</span><span class="o">|</span>
+<span class="w">    </span><span class="k">yield</span><span class="w"> </span><span class="vg">$2</span><span class="p">,</span><span class="w"> </span><span class="vg">$3</span>
+<span class="w">  </span><span class="k">end</span>
 <span class="k">end</span>
 </pre></div>
 <p>Now let&#8217;s test case-insensitive code blocks.</p>
 <div class="highlight"><pre><span></span><span class="c1"># Finds all emphasis matches in a string.</span>
 <span class="c1"># Supply a block that will get the marker and body as parameters.</span>
-<span class="k">def</span> <span class="nf">match_all</span><span class="p">(</span><span class="n">str</span><span class="p">)</span>
-  <span class="n">str</span><span class="o">.</span><span class="n">scan</span><span class="p">(</span><span class="vi">@org_emphasis_regexp</span><span class="p">)</span> <span class="k">do</span> <span class="o">|</span><span class="n">match</span><span class="o">|</span>
-    <span class="k">yield</span> <span class="vg">$2</span><span class="p">,</span> <span class="vg">$3</span>
-  <span class="k">end</span>
+<span class="k">def</span><span class="w"> </span><span class="nf">match_all</span><span class="p">(</span><span class="n">str</span><span class="p">)</span>
+<span class="w">  </span><span class="n">str</span><span class="o">.</span><span class="n">scan</span><span class="p">(</span><span class="vi">@org_emphasis_regexp</span><span class="p">)</span><span class="w"> </span><span class="k">do</span><span class="w"> </span><span class="o">|</span><span class="n">match</span><span class="o">|</span>
+<span class="w">    </span><span class="k">yield</span><span class="w"> </span><span class="vg">$2</span><span class="p">,</span><span class="w"> </span><span class="vg">$3</span>
+<span class="w">  </span><span class="k">end</span>
 <span class="k">end</span>
 </pre></div>
 <div class="highlight"><pre><span></span><span class="p">(</span><span class="k">def </span><span class="nv">fib-seq</span>
-  <span class="p">(</span><span class="nf">concat</span>
-   <span class="p">[</span><span class="mi">0</span> <span class="mi">1</span><span class="p">]</span>
-   <span class="p">((</span><span class="k">fn </span><span class="nv">rfib</span> <span class="p">[</span><span class="nv">a</span> <span class="nv">b</span><span class="p">]</span>
-        <span class="p">(</span><span class="nb">lazy-cons </span><span class="p">(</span><span class="nb">+ </span><span class="nv">a</span> <span class="nv">b</span><span class="p">)</span> <span class="p">(</span><span class="nf">rfib</span> <span class="nv">b</span> <span class="p">(</span><span class="nb">+ </span><span class="nv">a</span> <span class="nv">b</span><span class="p">))))</span> <span class="mi">0</span> <span class="mi">1</span><span class="p">)))</span>
- 
-<span class="nv">user&gt;</span> <span class="p">(</span><span class="nb">take </span><span class="mi">20</span> <span class="nv">fib-seq</span><span class="p">)</span>
-<span class="p">(</span><span class="mi">0</span> <span class="mi">1</span> <span class="mi">1</span> <span class="mi">2</span> <span class="mi">3</span> <span class="mi">5</span> <span class="mi">8</span> <span class="mi">13</span> <span class="mi">21</span> <span class="mi">34</span> <span class="mi">55</span> <span class="mi">89</span> <span class="mi">144</span> <span class="mi">233</span> <span class="mi">377</span> <span class="mi">610</span> <span class="mi">987</span> <span class="mi">1597</span> <span class="mi">2584</span> <span class="mi">4181</span><span class="p">)</span>
+<span class="w">  </span><span class="p">(</span><span class="nf">concat</span>
+<span class="w">   </span><span class="p">[</span><span class="mi">0</span><span class="w"> </span><span class="mi">1</span><span class="p">]</span>
+<span class="w">   </span><span class="p">((</span><span class="k">fn </span><span class="nv">rfib</span><span class="w"> </span><span class="p">[</span><span class="nv">a</span><span class="w"> </span><span class="nv">b</span><span class="p">]</span>
+<span class="w">        </span><span class="p">(</span><span class="nb">lazy-cons </span><span class="p">(</span><span class="nb">+ </span><span class="nv">a</span><span class="w"> </span><span class="nv">b</span><span class="p">)</span><span class="w"> </span><span class="p">(</span><span class="nf">rfib</span><span class="w"> </span><span class="nv">b</span><span class="w"> </span><span class="p">(</span><span class="nb">+ </span><span class="nv">a</span><span class="w"> </span><span class="nv">b</span><span class="p">))))</span><span class="w"> </span><span class="mi">0</span><span class="w"> </span><span class="mi">1</span><span class="p">)))</span>
+<span class="w"> </span>
+<span class="nv">user&gt;</span><span class="w"> </span><span class="p">(</span><span class="nb">take </span><span class="mi">20</span><span class="w"> </span><span class="nv">fib-seq</span><span class="p">)</span>
+<span class="p">(</span><span class="mi">0</span><span class="w"> </span><span class="mi">1</span><span class="w"> </span><span class="mi">1</span><span class="w"> </span><span class="mi">2</span><span class="w"> </span><span class="mi">3</span><span class="w"> </span><span class="mi">5</span><span class="w"> </span><span class="mi">8</span><span class="w"> </span><span class="mi">13</span><span class="w"> </span><span class="mi">21</span><span class="w"> </span><span class="mi">34</span><span class="w"> </span><span class="mi">55</span><span class="w"> </span><span class="mi">89</span><span class="w"> </span><span class="mi">144</span><span class="w"> </span><span class="mi">233</span><span class="w"> </span><span class="mi">377</span><span class="w"> </span><span class="mi">610</span><span class="w"> </span><span class="mi">987</span><span class="w"> </span><span class="mi">1597</span><span class="w"> </span><span class="mi">2584</span><span class="w"> </span><span class="mi">4181</span><span class="p">)</span>
 </pre></div>
 <p>Even if no language is set, it is still wrapped in code tags but class is empty.</p>
 <div class="highlight"><pre><span></span>echo &#39;Defaults env_keeps=&quot;http_proxy https_proxy ftp_proxy&quot;&#39; | sudo tee -a /etc/sudoers
@@ -52,27 +52,27 @@
     best things in the world!</p>
 </blockquote>
 <div class="highlight"><pre><span></span><span class="p">{</span>
-<span class="ss">:one</span> <span class="o">=&gt;</span> <span class="mi">1</span><span class="p">,</span>
-<span class="ss">:two</span> <span class="o">=&gt;</span> <span class="mi">2</span>
+<span class="ss">:one</span><span class="w"> </span><span class="o">=&gt;</span><span class="w"> </span><span class="mi">1</span><span class="p">,</span>
+<span class="ss">:two</span><span class="w"> </span><span class="o">=&gt;</span><span class="w"> </span><span class="mi">2</span>
 <span class="p">}</span>
 </pre></div>
-<div class="highlight"><pre><span></span><span class="p">(</span><span class="kd">defproject </span><span class="nv">helloworld</span> <span class="s">&quot;0.1&quot;</span>
-<span class="ss">:dependencies</span> <span class="p">[[</span><span class="nv">org.clojure/clojure</span>
-                 <span class="s">&quot;1.1.0-master-SNAPSHOT&quot;</span><span class="p">]</span>
-              <span class="p">[</span><span class="nv">org.clojure/clojure-contrib</span>
-                 <span class="s">&quot;1.0-SNAPSHOT&quot;</span><span class="p">]]</span>
-<span class="ss">:main</span> <span class="nv">helloworld</span><span class="p">)</span>
+<div class="highlight"><pre><span></span><span class="p">(</span><span class="kd">defproject </span><span class="nv">helloworld</span><span class="w"> </span><span class="s">&quot;0.1&quot;</span>
+<span class="ss">:dependencies</span><span class="w"> </span><span class="p">[[</span><span class="nv">org.clojure/clojure</span>
+<span class="w">                 </span><span class="s">&quot;1.1.0-master-SNAPSHOT&quot;</span><span class="p">]</span>
+<span class="w">              </span><span class="p">[</span><span class="nv">org.clojure/clojure-contrib</span>
+<span class="w">                 </span><span class="s">&quot;1.0-SNAPSHOT&quot;</span><span class="p">]]</span>
+<span class="ss">:main</span><span class="w"> </span><span class="nv">helloworld</span><span class="p">)</span>
 </pre></div>
 <h1><span class="heading-number heading-number-1">4</span> Code syntax highlight with Pygments</h1>
 <h2><span class="heading-number heading-number-2">4.1</span> No language selected</h2>
 <div class="highlight"><pre><span></span>&lt;script&gt;alert(&#39;hello world&#39;)&lt;/script&gt;
 </pre></div>
 <h2><span class="heading-number heading-number-2">4.2</span> CSS example</h2>
-<div class="highlight"><pre><span></span><span class="o">*</span> <span class="p">{</span>
- <span class="c">/* apply a natural box layout model to all elements */</span>
- <span class="k">box-sizing</span><span class="p">:</span> <span class="kc">border-box</span><span class="p">;</span> 
- <span class="kp">-moz-</span><span class="k">box-sizing</span><span class="p">:</span> <span class="kc">border-box</span><span class="p">;</span> 
- <span class="kp">-webkit-</span><span class="k">box-sizing</span><span class="p">:</span> <span class="kc">border-box</span><span class="p">;</span> 
+<div class="highlight"><pre><span></span><span class="o">*</span><span class="w"> </span><span class="p">{</span>
+<span class="w"> </span><span class="c">/* apply a natural box layout model to all elements */</span>
+<span class="w"> </span><span class="k">box-sizing</span><span class="p">:</span><span class="w"> </span><span class="kc">border-box</span><span class="p">;</span><span class="w"> </span>
+<span class="w"> </span><span class="kp">-moz-</span><span class="k">box-sizing</span><span class="p">:</span><span class="w"> </span><span class="kc">border-box</span><span class="p">;</span><span class="w"> </span>
+<span class="w"> </span><span class="kp">-webkit-</span><span class="k">box-sizing</span><span class="p">:</span><span class="w"> </span><span class="kc">border-box</span><span class="p">;</span><span class="w"> </span>
 <span class="p">}</span>
 </pre></div>
 <h2><span class="heading-number heading-number-2">4.3</span> HTML example</h2>
@@ -86,10 +86,10 @@
 <span class="p">&lt;/</span><span class="nt">html</span><span class="p">&gt;</span>
 </pre></div>
 <h2><span class="heading-number heading-number-2">4.4</span> Ruby example</h2>
-<div class="highlight"><pre><span></span><span class="k">class</span> <span class="nc">Post</span> <span class="o">&lt;&lt;</span> <span class="no">ActiveRecord</span><span class="o">::</span><span class="no">Base</span>
-  <span class="k">def</span> <span class="nf">print_title</span>
-    <span class="nb">puts</span> <span class="s2">&quot;</span><span class="si">#{</span><span class="nb">self</span><span class="o">.</span><span class="n">title</span><span class="si">}</span><span class="s2">&quot;</span>
-  <span class="k">end</span>
+<div class="highlight"><pre><span></span><span class="k">class</span><span class="w"> </span><span class="nc">Post</span><span class="w"> </span><span class="o">&lt;&lt;</span><span class="w"> </span><span class="no">ActiveRecord</span><span class="o">::</span><span class="no">Base</span>
+<span class="w">  </span><span class="k">def</span><span class="w"> </span><span class="nf">print_title</span>
+<span class="w">    </span><span class="nb">puts</span><span class="w"> </span><span class="s2">&quot;</span><span class="si">#{</span><span class="nb">self</span><span class="o">.</span><span class="n">title</span><span class="si">}</span><span class="s2">&quot;</span>
+<span class="w">  </span><span class="k">end</span>
 <span class="k">end</span>
 </pre></div>
 <h2><span class="heading-number heading-number-2">4.5</span> Python example</h2>
@@ -99,21 +99,21 @@
 <span class="n">m</span><span class="o">.</span><span class="n">background</span> <span class="o">=</span> <span class="n">Map</span><span class="o">.</span><span class="n">Color</span><span class="p">(</span><span class="s1">&#39;steelblue&#39;</span><span class="p">)</span>
 </pre></div>
 <h2><span class="heading-number heading-number-2">4.6</span> Javascript example</h2>
-<div class="highlight"><pre><span></span><span class="nx">exports</span> <span class="o">=</span> <span class="k">this</span><span class="p">;</span>
+<div class="highlight"><pre><span></span><span class="nx">exports</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="k">this</span><span class="p">;</span>
 
 <span class="p">(</span><span class="kd">function</span><span class="p">(</span><span class="nx">$</span><span class="p">){</span>
 
-<span class="kd">var</span> <span class="nx">Posts</span> <span class="o">=</span> <span class="p">{};</span>
+<span class="kd">var</span><span class="w"> </span><span class="nx">Posts</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="p">{};</span>
 
-<span class="nx">Posts</span><span class="p">.</span><span class="nx">index</span> <span class="o">=</span> <span class="kd">function</span><span class="p">(){</span>
+<span class="nx">Posts</span><span class="p">.</span><span class="nx">index</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="kd">function</span><span class="p">(){</span>
 <span class="c1">// TODO</span>
 <span class="p">};</span>
 
 <span class="p">})(</span><span class="nx">jQuery</span><span class="p">);</span>
 </pre></div>
 <h2><span class="heading-number heading-number-2">4.7</span> JSON example</h2>
-<div class="highlight"><pre><span></span><span class="p">{</span> <span class="err">name:</span> <span class="nt">&quot;Waldemar&quot;</span>
-<span class="p">,</span> <span class="err">surname:</span> <span class="nt">&quot;Quevedo&quot;</span>
+<div class="highlight"><pre><span></span><span class="p">{</span><span class="w"> </span><span class="kc">na</span><span class="err">me</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Waldemar&quot;</span>
+<span class="p">,</span><span class="w"> </span><span class="err">sur</span><span class="kc">na</span><span class="err">me</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Quevedo&quot;</span>
 <span class="p">}</span>
 </pre></div>
 <h2><span class="heading-number heading-number-2">4.8</span> PHP example</h2>
@@ -122,9 +122,9 @@
 <span class="x">var_dump(some_var);</span>
 </pre></div>
 <h2><span class="heading-number heading-number-2">4.9</span> Elisp example</h2>
-<div class="highlight"><pre><span></span><span class="p">(</span><span class="nf">defun</span> <span class="nv">hello</span><span class="p">()</span>
-  <span class="p">(</span><span class="nf">interactive</span><span class="p">)</span>
-  <span class="p">(</span><span class="nf">message</span> <span class="s">&quot;hello&quot;</span><span class="p">))</span>
+<div class="highlight"><pre><span></span><span class="p">(</span><span class="nf">defun</span><span class="w"> </span><span class="nv">hello</span><span class="p">()</span>
+<span class="w">  </span><span class="p">(</span><span class="nf">interactive</span><span class="p">)</span>
+<span class="w">  </span><span class="p">(</span><span class="nf">message</span><span class="w"> </span><span class="s">&quot;hello&quot;</span><span class="p">))</span>
 </pre></div>
 <h2><span class="heading-number heading-number-2">4.10</span> Not supported language example</h2>
 <div class="highlight"><pre><span></span>!+!+++!++!++!++!+

--- a/spec/html_code_syntax_highlight_examples/code-block-exports-pygments.html
+++ b/spec/html_code_syntax_highlight_examples/code-block-exports-pygments.html
@@ -4,35 +4,35 @@
 <h1>About the <code>#+RESULTS:</code> block</h1>
 <p>Using Org Babel features, it is possible to set <code>:results output</code>
   to a code block and render the results within a <code>#+RESULTS:</code> code block:</p>
-<div class="highlight"><pre><span></span>#+begin_src ruby :results output :exports both
+<div class="highlight"><pre><span></span><span class="ow">#+begin_src ruby :results output :exports both</span>
 puts &quot;Hello world&quot;
-#+end_src
+<span class="ow">#+end_src</span>
 
-#+RESULTS:
+<span class="nn">#+RESULTS:</span>
 : Hello world
 </pre></div>
 <p>One thing about the <code>#+RESULTS:</code> code blocks, is that they exist in several forms:</p>
 <ol>
   <li>As an accumulated group of inline examples:
-<div class="highlight"><pre><span></span>#+begin_src python :results output :exports both
+<div class="highlight"><pre><span></span><span class="ow">#+begin_src python :results output :exports both</span>
 print &quot;like&quot;
 print &quot;this&quot;
 print &quot;etc...&quot;
-#+end_src
+<span class="ow">#+end_src</span>
 
-#+RESULTS:
+<span class="nn">#+RESULTS:</span>
 : like
 : this
 : etc...
 </pre></div>
   </li>
   <li>As an example code block.
-<div class="highlight"><pre><span></span>#+begin_src ruby :results output :exports both
+<div class="highlight"><pre><span></span><span class="ow">#+begin_src ruby :results output :exports both</span>
 10.times {|n| puts n }
-#+end_src
+<span class="ow">#+end_src</span>
 
-#+RESULTS:
-#+begin_example
+<span class="nn">#+RESULTS:</span>
+<span class="ow">#+begin_example</span>
 0
 1
 2
@@ -43,19 +43,19 @@ print &quot;etc...&quot;
 7
 8
 9
-#+end_example
+<span class="ow">#+end_example</span>
 </pre></div>
   </li>
   <li>Also, in case <code>:results output code</code> is used, the results would
     be a src block of the same language as the original one.
-<div class="highlight"><pre><span></span>#+begin_src ruby :results output code
+<div class="highlight"><pre><span></span><span class="ow">#+begin_src ruby :results output code</span>
 counter = 0
 10.times { puts &quot;puts &#39;#{counter += 1}&#39;&quot; } # Displayed in first code block
 puts counter # Displayed in second code block
-#+end_src
+<span class="ow">#+end_src</span>
 
-#+RESULTS:
-#+begin_src ruby
+<span class="nn">#+RESULTS:</span>
+<span class="ow">#+begin_src ruby</span>
 puts &#39;1&#39;
 puts &#39;2&#39;
 puts &#39;3&#39;
@@ -67,9 +67,9 @@ puts &#39;8&#39;
 puts &#39;9&#39;
 puts &#39;10&#39;
 10
-#+end_src
+<span class="ow">#+end_src</span>
 
-#+RESULTS:
+<span class="nn">#+RESULTS:</span>
 : 10
 </pre></div>
   </li>
@@ -78,26 +78,26 @@ puts &#39;10&#39;
 <p>The default is to export only the code blocks.</p>
 <p>The following is an code block written in Emacs Lisp
   and its result should not be exported.</p>
-<div class="highlight"><pre><span></span><span class="p">(</span><span class="nf">message</span> <span class="s">&quot;hello world&quot;</span><span class="p">)</span>
+<div class="highlight"><pre><span></span><span class="p">(</span><span class="nf">message</span><span class="w"> </span><span class="s">&quot;hello world&quot;</span><span class="p">)</span>
 </pre></div>
 <p>The following is a code block written in Python
   and its result should not be exported.</p>
 <div class="highlight"><pre><span></span><span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span><span class="mi">12</span><span class="p">):</span>
-  <span class="k">print</span> <span class="s2">&quot;import this&quot;</span>
+  <span class="nb">print</span> <span class="s2">&quot;import this&quot;</span>
 </pre></div>
 <p>
 </p>
 <h1>:exports code</h1>
 <p>Only the code would be in the output,
   the same as when no option is set.</p>
-<div class="highlight"><pre><span></span><span class="kd">var</span> <span class="nx">message</span> <span class="o">=</span> <span class="s2">&quot;Hello world!&quot;</span><span class="p">;</span>
+<div class="highlight"><pre><span></span><span class="kd">var</span><span class="w"> </span><span class="nx">message</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s2">&quot;Hello world!&quot;</span><span class="p">;</span>
 
 <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="nx">message</span><span class="p">);</span>
 </pre></div>
 <p>And as block example too:</p>
-<div class="highlight"><pre><span></span><span class="kd">var</span> <span class="nx">message</span> <span class="o">=</span> <span class="s2">&quot;Hello world!&quot;</span><span class="p">;</span>
-<span class="k">for</span> <span class="p">(</span><span class="kd">var</span> <span class="nx">i</span> <span class="o">=</span> <span class="mi">0</span><span class="p">;</span> <span class="nx">i</span><span class="o">&lt;</span> <span class="mi">10</span><span class="p">;</span> <span class="nx">i</span><span class="o">++</span><span class="p">)</span> <span class="p">{</span>
-  <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="nx">message</span><span class="p">);</span>
+<div class="highlight"><pre><span></span><span class="kd">var</span><span class="w"> </span><span class="nx">message</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s2">&quot;Hello world!&quot;</span><span class="p">;</span>
+<span class="k">for</span><span class="w"> </span><span class="p">(</span><span class="kd">var</span><span class="w"> </span><span class="nx">i</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="mf">0</span><span class="p">;</span><span class="w"> </span><span class="nx">i</span><span class="o">&lt;</span><span class="w"> </span><span class="mf">10</span><span class="p">;</span><span class="w"> </span><span class="nx">i</span><span class="o">++</span><span class="p">)</span><span class="w"> </span><span class="p">{</span>
+<span class="w">  </span><span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="nx">message</span><span class="p">);</span>
 <span class="p">}</span>
 </pre></div>
 <p>
@@ -109,13 +109,13 @@ puts &#39;10&#39;
 <p>
 </p>
 <h1>:exports both</h1>
-<div class="highlight"><pre><span></span><span class="no">Math</span><span class="o">::</span><span class="no">PI</span> <span class="o">+</span> <span class="mi">1</span>
+<div class="highlight"><pre><span></span><span class="no">Math</span><span class="o">::</span><span class="no">PI</span><span class="w"> </span><span class="o">+</span><span class="w"> </span><span class="mi">1</span>
 </pre></div>
 <pre class="example">
 4.14159265358979
 </pre>
 <p>Should behave the same when within a block example.</p>
-<div class="highlight"><pre><span></span><span class="n">hello</span> <span class="o">=</span> <span class="o">&lt;&lt;</span><span class="dl">HELLO</span>
+<div class="highlight"><pre><span></span><span class="n">hello</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="o">&lt;&lt;</span><span class="dl">HELLO</span>
 <span class="sh">The following is a text</span>
 <span class="sh">that will contain at least 10 lines or more</span>
 <span class="sh">so that when C-c C-c is pressed</span>

--- a/spec/html_code_syntax_highlight_examples/code-pygments.html
+++ b/spec/html_code_syntax_highlight_examples/code-pygments.html
@@ -1,13 +1,13 @@
 <h1>Simple Code Syntax highlighting test</h1>
-<div class="highlight"><pre><span></span><span class="k">class</span> <span class="nc">Pygments</span>
-  <span class="k">class</span> <span class="o">&lt;&lt;</span> <span class="nb">self</span>
-    <span class="k">def</span> <span class="nf">colorize</span>
-      <span class="c1"># Do colorizing stuff here</span>
-      <span class="n">heredoc</span> <span class="o">=</span> <span class="o">&lt;&lt;</span><span class="dl">EOF</span>
+<div class="highlight"><pre><span></span><span class="k">class</span><span class="w"> </span><span class="nc">Pygments</span>
+<span class="w">  </span><span class="k">class</span><span class="w"> </span><span class="o">&lt;&lt;</span><span class="w"> </span><span class="nb">self</span>
+<span class="w">    </span><span class="k">def</span><span class="w"> </span><span class="nf">colorize</span>
+<span class="w">      </span><span class="c1"># Do colorizing stuff here</span>
+<span class="w">      </span><span class="n">heredoc</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="o">&lt;&lt;</span><span class="dl">EOF</span>
 <span class="sh">    Some text yay!!!</span>
 <span class="dl">EOF</span>
-    <span class="k">end</span>
-  <span class="k">end</span>
+<span class="w">    </span><span class="k">end</span>
+<span class="w">  </span><span class="k">end</span>
 <span class="k">end</span>
 </pre></div>
 <p>Now using EXAMPLE blocks instead:</p>
@@ -24,10 +24,10 @@ class Hello
   end
 end
 </pre>
-<div class="highlight"><pre><span></span><span class="k">class</span> <span class="nc">Piano</span>
-  <span class="k">def</span> <span class="nf">play_note</span><span class="p">(</span><span class="n">note</span><span class="p">)</span>
-  <span class="c1"># TODO</span>
-  <span class="k">end</span>
+<div class="highlight"><pre><span></span><span class="k">class</span><span class="w"> </span><span class="nc">Piano</span>
+<span class="w">  </span><span class="k">def</span><span class="w"> </span><span class="nf">play_note</span><span class="p">(</span><span class="n">note</span><span class="p">)</span>
+<span class="w">  </span><span class="c1"># TODO</span>
+<span class="w">  </span><span class="k">end</span>
 <span class="k">end</span>
 </pre></div>
 <h1>When including a file as an src code file</h1>

--- a/spec/html_code_syntax_highlight_examples/prepended-comma-pygments.html
+++ b/spec/html_code_syntax_highlight_examples/prepended-comma-pygments.html
@@ -4,36 +4,36 @@
   this prepended comma should be removed before parsing.</p>
 <p>(Fixes <a href="https://github.com/bdewey/org-ruby/issues/50">https://github.com/bdewey/org-ruby/issues/50</a>)</p>
 <h2>Here the prepended comma will be removed.</h2>
-<div class="highlight"><pre><span></span>* Hello
-** Goodbye
- *** Not a headline, but prepended comma still removed.
-* I am a headline
+<div class="highlight"><pre><span></span><span class="gh">* Hello</span>
+<span class="gu">** Goodbye</span>
+ <span class="gs">***</span> Not a headline, but prepended comma still removed.
+<span class="gh">* I am a headline</span>
 </pre></div>
 <h2>Here the prepended comma is should not be removed.</h2>
 <div class="highlight"><pre><span></span><span class="p">{</span>
-  <span class="s2">&quot;one&quot;</span><span class="o">:</span>   <span class="mi">1</span>
-<span class="p">,</span> <span class="s2">&quot;two&quot;</span><span class="o">:</span>   <span class="mi">2</span>
-<span class="p">,</span> <span class="s2">&quot;three&quot;</span><span class="o">:</span> <span class="mi">3</span>
-<span class="p">,</span> <span class="s2">&quot;four&quot;</span><span class="o">:</span>  <span class="mi">4</span>
+<span class="w">  </span><span class="s2">&quot;one&quot;</span><span class="o">:</span><span class="w">   </span><span class="mf">1</span>
+<span class="p">,</span><span class="w"> </span><span class="s2">&quot;two&quot;</span><span class="o">:</span><span class="w">   </span><span class="mf">2</span>
+<span class="p">,</span><span class="w"> </span><span class="s2">&quot;three&quot;</span><span class="o">:</span><span class="w"> </span><span class="mf">3</span>
+<span class="p">,</span><span class="w"> </span><span class="s2">&quot;four&quot;</span><span class="o">:</span><span class="w">  </span><span class="mf">4</span>
 <span class="p">}</span>
 </pre></div>
 <h2>Here the prepended comma is also removed</h2>
 <p>Emacs Org mode implementation also removes it.</p>
-<div class="highlight"><pre><span></span><span class="n">text</span> <span class="o">=</span> <span class="o">&lt;&lt;</span><span class="dl">TEXT</span>
+<div class="highlight"><pre><span></span><span class="n">text</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="o">&lt;&lt;</span><span class="dl">TEXT</span>
 <span class="sh">#+TITLE: Prepended comma world</span>
 <span class="sh">* Hello world</span>
 <span class="sh">More text here</span>
 <span class="dl">TEXT</span>
 </pre></div>
 <h2>Here the prepended comma will be remove for the <code>Hello world</code> headline</h2>
-<div class="highlight"><pre><span></span>,  ,* Hi
-,  
-,  ,* This will be appended a comma
-* Hello world  
+<div class="highlight"><pre><span></span>,  ,<span class="gs">* Hi</span>
+<span class="gs">,  </span>
+<span class="gs">,  ,*</span> This will be appended a comma
+<span class="gh">* Hello world  </span>
 ,  
 </pre></div>
 <h2>Here the prepended comma will be removed</h2>
-<div class="highlight"><pre><span></span>#+TITLE: &quot;Hello world&quot;
+<div class="highlight"><pre><span></span><span class="nn">#+TITLE:</span> &quot;Hello world&quot;
 </pre></div>
 <h2>This will be rendered as normal</h2>
 <div class="highlight"><pre><span></span>,,,,,,,,,,,,,,,,,*Hello world

--- a/spec/html_code_syntax_highlight_examples/src-code-list-pygments.html
+++ b/spec/html_code_syntax_highlight_examples/src-code-list-pygments.html
@@ -1,20 +1,20 @@
 <h1>begin src in lists should work</h1>
 <ul>
   <li>Foo
-<div class="highlight"><pre><span></span><span class="k">class</span> <span class="nc">Hello</span>
-  <span class="k">def</span> <span class="nf">say</span>
-    <span class="nb">puts</span> <span class="s1">&#39;cheers&#39;</span>
-  <span class="k">end</span>
+<div class="highlight"><pre><span></span><span class="k">class</span><span class="w"> </span><span class="nc">Hello</span>
+<span class="w">  </span><span class="k">def</span><span class="w"> </span><span class="nf">say</span>
+<span class="w">    </span><span class="nb">puts</span><span class="w"> </span><span class="s1">&#39;cheers&#39;</span>
+<span class="w">  </span><span class="k">end</span>
 <span class="k">end</span>
 </pre></div>
   </li>
   <li>Bar
-<div class="highlight"><pre><span></span><span class="nb">puts</span> <span class="s2">&quot;This should not get lumped into the above line Example&quot;</span>
+<div class="highlight"><pre><span></span><span class="nb">puts</span><span class="w"> </span><span class="s2">&quot;This should not get lumped into the above line Example&quot;</span>
 </pre></div>
     <p>A paragraph should go here.</p>
     <ul>
       <li>A sublist goes here with another example
-<div class="highlight"><pre><span></span><span class="nb">echo</span> <span class="s2">&quot;Hello&quot;</span>
+<div class="highlight"><pre><span></span><span class="nb">echo</span><span class="w"> </span><span class="s2">&quot;Hello&quot;</span>
 </pre></div>
         <p>And this is a paragraph</p>
       </li>


### PR DESCRIPTION
This updates the test fixtures for the updated output highlighters like pygment gives on modern versions. It also removes the deprecated calls to `File.exists?`.

These changes together get the test suite passing on modern Ruby versions with modern gems.

This partially duplicates the work in https://github.com/wallyqs/org-ruby/pull/101 by @graaff, so feel free to merge that PR and I can remove the `File.exists?` part of this PR, but I include both otherwise tests tests are left failing.