### PR TITLE
Marks strings as mutable in preparation for Ruby freezing strings

### DIFF
--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Orgmode
 
   class HtmlOutputBuffer < OutputBuffer
@@ -191,7 +193,7 @@ module Orgmode
           @output << inline_formatting(@buffer)
         end
       end
-      @buffer = ""
+      @buffer = +""
     end
 
     def add_line_attributes headline
@@ -214,7 +216,7 @@ module Orgmode
 
       @output << "\n<div id=\"footnotes\">\n<h2 class=\"footnotes\">Footnotes:</h2>\n<div id=\"text-footnotes\">\n"
       @footnotes.each do |name, (defi, content)|
-        @buffer = defi
+        @buffer = +defi
         @output << "<div class=\"footdef\"><sup><a id=\"fn.#{name}\" href=\"#fnr.#{name}\">#{name}</a></sup>" \
                 << "<p class=\"footpara\">" \
                 << inline_formatting(@buffer) \
@@ -424,7 +426,7 @@ module Orgmode
     #      # => "Usage: foo &quot;bar&quot; &lt;baz&gt;"
     private
     def escapeHTML(string)
-      string.gsub(/['&\"<>]/, TABLE_FOR_ESCAPE_HTML__)
+      +(string.gsub(/['&\"<>]/, TABLE_FOR_ESCAPE_HTML__))
     end
   end                           # class HtmlOutputBuffer
 end                             # module Orgmode

--- a/lib/org-ruby/markdown_output_buffer.rb
+++ b/lib/org-ruby/markdown_output_buffer.rb
@@ -105,7 +105,7 @@ module Orgmode
         end
         @output << inline_formatting(@buffer) << "\n"
       end
-      @buffer = ""
+      @buffer = +""
     end
 
     def add_line_attributes headline

--- a/lib/org-ruby/output_buffer.rb
+++ b/lib/org-ruby/output_buffer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'logger'
 
 module Orgmode
@@ -20,7 +22,7 @@ module Orgmode
       # This is the accumulation buffer. It's a holding pen so
       # consecutive lines of the right type can get stuck together
       # without intervening newlines.
-      @buffer = ""
+      @buffer = +""
 
       # This stack is used to do proper outline numbering of
       # headlines.

--- a/lib/org-ruby/parser.rb
+++ b/lib/org-ruby/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubypants'
 
 module Orgmode
@@ -301,7 +303,7 @@ module Orgmode
 
     # Saves the loaded orgmode file as a textile file.
     def to_textile
-      output = ""
+      output = +""
       output_buffer = TextileOutputBuffer.new(output)
 
       translate(@header_lines, output_buffer)
@@ -317,7 +319,7 @@ module Orgmode
       export_options = {
         :markup_file        => @parser_options[:markup_file]
       }
-      output = ""
+      output = +""
       output_buffer = MarkdownOutputBuffer.new(output, export_options)
 
       translate(@header_lines, output_buffer)
@@ -349,7 +351,7 @@ module Orgmode
         :markup_file           => @parser_options[:markup_file]
       }
       export_options[:skip_tables] = true if not export_tables?
-      output = ""
+      output = +""
       output_buffer = HtmlOutputBuffer.new(output, export_options)
 
       if @in_buffer_settings["TITLE"]

--- a/lib/org-ruby/textile_output_buffer.rb
+++ b/lib/org-ruby/textile_output_buffer.rb
@@ -144,7 +144,7 @@ module Orgmode
         end
         @output << inline_formatting(@buffer) << "\n"
       end
-      @buffer = ""
+      @buffer = +""
     end
 
     def add_line_attributes headline

--- a/spec/regexp_helper_spec.rb
+++ b/spec/regexp_helper_spec.rb
@@ -40,7 +40,7 @@ describe Orgmode::RegexpHelper do
       "/" => "i",
       "~" => "code"
     }
-    n = e.rewrite_emphasis("This string contains *bold*, /italic/, and ~verbatim~ text.") do |border, str|
+    n = e.rewrite_emphasis(+"This string contains *bold*, /italic/, and ~verbatim~ text.") do |border, str|
       "<#{map[border]}>#{str}</#{map[border]}>"
     end
     n = e.restore_code_snippets n
@@ -50,15 +50,15 @@ describe Orgmode::RegexpHelper do
 
   it "should allow link rewriting" do
     e = Orgmode::RegexpHelper.new
-    str = e.rewrite_links("[[http://www.bing.com]]") do |link,text|
+    str = e.rewrite_links(+"[[http://www.bing.com]]") do |link,text|
       text ||= link
       "\"#{text}\":#{link}"
     end
     expect(str).to eql("\"http://www.bing.com\":http://www.bing.com")
-    str = e.rewrite_links("<http://www.google.com>") do |link|
+    str = e.rewrite_links(+"<http://www.google.com>") do |link|
       "\"#{link}\":#{link}"
     end
-    expect(str).to eql("\"http://www.google.com\":http://www.google.com")
+    expect(str).to eql(+"\"http://www.google.com\":http://www.google.com")
   end
 
   it "should allow quotes within code markup" do
@@ -66,7 +66,7 @@ describe Orgmode::RegexpHelper do
     map = {
       "~" => "code"
     }
-    n = e.rewrite_emphasis('This string contains a quote using code markup: ~"~') do |border, str|
+    n = e.rewrite_emphasis(+'This string contains a quote using code markup: ~"~') do |border, str|
       "<#{map[border]}>#{str}</#{map[border]}>"
     end
     n = e.restore_code_snippets n

--- a/spec/textile_output_buffer_spec.rb
+++ b/spec/textile_output_buffer_spec.rb
@@ -2,20 +2,20 @@ require 'spec_helper'
 
 describe Orgmode::TextileOutputBuffer do
   it "should substitute / with _" do
-    expect(Orgmode::TextileOutputBuffer.new("").inline_formatting("/italic/")).to eql("_italic_")
+    expect(Orgmode::TextileOutputBuffer.new("").inline_formatting(+"/italic/")).to eql("_italic_")
   end
 
   it "should convert simple links" do
-    expect(Orgmode::TextileOutputBuffer.new("").inline_formatting("[[http://www.google.com]]")).to \
+    expect(Orgmode::TextileOutputBuffer.new("").inline_formatting(+"[[http://www.google.com]]")).to \
       eql("\"http://www.google.com\":http://www.google.com")
   end
 
   it "should convert links with text" do
-    expect(Orgmode::TextileOutputBuffer.new("").inline_formatting("[[http://www.google.com][Google]]")).to \
+    expect(Orgmode::TextileOutputBuffer.new("").inline_formatting(+"[[http://www.google.com][Google]]")).to \
       eql("\"Google\":http://www.google.com")
   end
 
   it "should convert spaces in urls" do
-    expect(Orgmode::TextileOutputBuffer.new("").inline_formatting("[[my url]]")).to eql("\"my url\":my%20url")
+    expect(Orgmode::TextileOutputBuffer.new("").inline_formatting(+"[[my url]]")).to eql("\"my url\":my%20url")
   end
 end

--- a/spec/textile_output_buffer_spec.rb
+++ b/spec/textile_output_buffer_spec.rb
@@ -16,6 +16,6 @@ describe Orgmode::TextileOutputBuffer do
   end
 
   it "should convert spaces in urls" do
-    expect(Orgmode::TextileOutputBuffer.new("").inline_formatting(+"[[my url]]")).to eql("\"my url\":my%20url")
+    expect(Orgmode::TextileOutputBuffer.new("").inline_fgit ormatting(+"[[my url]]")).to eql("\"my url\":my%20url")
   end
 end


### PR DESCRIPTION
There was a deprecation warning for chilled strings merged recently in Ruby: https://github.com/ruby/ruby/commit/12be40ae6be78ac41e8e3f3c313cc6f63e7fa6c4

And with that we started to see the following warning coming from `org-ruby`:

```
vendor/gems/3.4.0/ruby/3.4.0+0/gems/org-ruby-0.9.12/lib/org-ruby/html_output_buffer.rb:85: warning: literal string will be frozen in the future
```

This makes updates to freeze strings by default and mark  others unfrozen where needed in order to maintain functionality with smallest changes possible.